### PR TITLE
Fix duplicate first message in web UI

### DIFF
--- a/golem-xiv-presenter/src/commonMain/kotlin/MainPresenter.kt
+++ b/golem-xiv-presenter/src/commonMain/kotlin/MainPresenter.kt
@@ -151,21 +151,22 @@ class MainPresenter(
                 }
                 is Navigation.Target.Cognition -> {
                     resetCognition(cognitionId = target.id)
-                    try {
-                        cognitionService.emitCognition(id = target.id)
-                    } catch (e: GolemServiceException) {
-                        if (e.error is GolemError.NoSuchCognition) {
-                            navigation.navigateTo(Navigation.Target.NotFound(
-                                message = "Cognition not found",
-                                pathname = "/cognitions/${target.id}"
-                            ))
-                        } else {
-                            throw e
+                    // Only replay stored messages when navigating to an existing cognition,
+                    // not when transitioning from InitiateCognition (first message already streaming)
+                    if (currentNavigationTarget !is Navigation.Target.InitiateCognition) {
+                        try {
+                            cognitionService.emitCognition(id = target.id)
+                        } catch (e: GolemServiceException) {
+                            if (e.error is GolemError.NoSuchCognition) {
+                                navigation.navigateTo(Navigation.Target.NotFound(
+                                    message = "Cognition not found",
+                                    pathname = "/cognitions/${target.id}"
+                                ))
+                            } else {
+                                throw e
+                            }
                         }
                     }
-                    if ((currentNavigationTarget == null) || (currentNavigationTarget !is Navigation.Target.InitiateCognition)) {
-
-                    } // else we keep the same view, just the pathname has changed
                 }
                 is Navigation.Target.Memory -> {
                     view.display(memoryView)


### PR DESCRIPTION
## Problem

When sending the first message in a new cognition, it would appear twice in the UI. Refreshing the page or sending subsequent messages worked correctly.

Root cause: When the first message is sent, the navigation changes from InitiateCognition to Cognition. This triggered both:
1. The live SSE stream (already delivering the response)
2. A call to emitCognition() which replays all stored messages via SSE

Both paths fed into the same MutableSharedFlow, causing the new CognitionPresenter to receive each message twice.

## Solution

Only call emitCognition() when navigating to an existing cognition (e.g., from history or direct URL), not when transitioning from InitiateCognition where the SSE stream is already active.