### PR TITLE
Add Past Cognitions List in UI and Auto-Generated Titles

### DIFF
--- a/golem-xiv-api-backend/src/main/kotlin/CognitionApi.kt
+++ b/golem-xiv-api-backend/src/main/kotlin/CognitionApi.kt
@@ -18,6 +18,7 @@
 
 package com.xemantic.ai.golem.api.backend
 
+import com.xemantic.ai.golem.api.CognitionListItem
 import com.xemantic.ai.golem.api.EpistemicAgent
 import com.xemantic.ai.golem.api.PhenomenalExpression
 import com.xemantic.ai.golem.api.Phenomenon
@@ -111,6 +112,15 @@ interface CognitionRepository {
         cognitionId: Long
     ): Phenomenon.Intent?
 
+    suspend fun listCognitions(
+        limit: Int = 50,
+        offset: Int = 0
+    ): List<CognitionListItem>
+
+    suspend fun isFirstExpression(
+        cognitionId: Long
+    ): Boolean
+
 }
 
 interface CognitiveMemory {
@@ -177,6 +187,15 @@ interface CognitiveMemory {
         phenomenonId: Long,
         type: StorageType
     ): String
+
+    suspend fun listCognitions(
+        limit: Int = 50,
+        offset: Int = 0
+    ): List<CognitionListItem>
+
+    suspend fun getExpressionCount(
+        cognitionId: Long
+    ): Int
 
 }
 

--- a/golem-xiv-api-backend/src/main/kotlin/TitleGenerator.kt
+++ b/golem-xiv-api-backend/src/main/kotlin/TitleGenerator.kt
@@ -1,0 +1,25 @@
+/*
+ * Golem XIV - Autonomous metacognitive AI system with semantic memory and self-directed research
+ * Copyright (C) 2025  Kazimierz Pogoda / Xemantic
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.xemantic.ai.golem.api.backend
+
+interface TitleGenerator {
+
+    suspend fun generateTitle(userMessage: String): String
+
+}

--- a/golem-xiv-api-client/src/commonMain/kotlin/GolemServices.kt
+++ b/golem-xiv-api-client/src/commonMain/kotlin/GolemServices.kt
@@ -18,6 +18,7 @@
 
 package com.xemantic.ai.golem.api.client
 
+import com.xemantic.ai.golem.api.CognitionListItem
 import com.xemantic.ai.golem.api.GolemError
 import com.xemantic.ai.golem.api.Phenomenon
 
@@ -50,6 +51,11 @@ interface CognitionService {
         id: Long,
         phenomena: List<Phenomenon>
     )
+
+    suspend fun listCognitions(
+        limit: Int = 50,
+        offset: Int = 0
+    ): List<CognitionListItem>
 
 }
 

--- a/golem-xiv-api-client/src/commonMain/kotlin/http/CognitionService.kt
+++ b/golem-xiv-api-client/src/commonMain/kotlin/http/CognitionService.kt
@@ -18,6 +18,7 @@
 
 package com.xemantic.ai.golem.api.client.http
 
+import com.xemantic.ai.golem.api.CognitionListItem
 import com.xemantic.ai.golem.api.Phenomenon
 import com.xemantic.ai.golem.api.client.CognitionService
 import io.ktor.client.HttpClient
@@ -46,5 +47,12 @@ class HttpClientCognitionService(
             value = phenomena
         )
     }
+
+    override suspend fun listCognitions(
+        limit: Int,
+        offset: Int
+    ): List<CognitionListItem> = client.serviceGet(
+        uri = "/api/cognitions?limit=$limit&offset=$offset"
+    )
 
 }

--- a/golem-xiv-api/src/commonMain/kotlin/Cognition.kt
+++ b/golem-xiv-api/src/commonMain/kotlin/Cognition.kt
@@ -102,3 +102,10 @@ sealed interface Phenomenon {
     ) : Phenomenon
 
 }
+
+@Serializable
+data class CognitionListItem(
+    val id: Long,
+    val title: String?,
+    val initiationMoment: Instant
+)

--- a/golem-xiv-api/src/commonMain/kotlin/GolemOutput.kt
+++ b/golem-xiv-api/src/commonMain/kotlin/GolemOutput.kt
@@ -63,4 +63,11 @@ sealed interface GolemOutput {
         val event: CognitionEvent
     ) : GolemOutput, WithCognitionId
 
+    @Serializable
+    @SerialName("CognitionTitleUpdated")
+    data class CognitionTitleUpdated(
+        override val cognitionId: Long,
+        val title: String
+    ) : GolemOutput, WithCognitionId
+
 }

--- a/golem-xiv-cognizer-anthropic/src/main/kotlin/AnthropicTitleGenerator.kt
+++ b/golem-xiv-cognizer-anthropic/src/main/kotlin/AnthropicTitleGenerator.kt
@@ -1,0 +1,50 @@
+/*
+ * Golem XIV - Autonomous metacognitive AI system with semantic memory and self-directed research
+ * Copyright (C) 2025  Kazimierz Pogoda / Xemantic
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.xemantic.ai.golem.cognizer.anthropic
+
+import com.xemantic.ai.anthropic.Anthropic
+import com.xemantic.ai.anthropic.content.Text
+import com.xemantic.ai.anthropic.message.Message
+import com.xemantic.ai.anthropic.message.Role
+import com.xemantic.ai.golem.api.backend.TitleGenerator
+
+class AnthropicTitleGenerator(
+    private val anthropic: Anthropic
+) : TitleGenerator {
+
+    override suspend fun generateTitle(userMessage: String): String {
+        val response = anthropic.messages.create {
+            maxTokens = 30
+            messages = listOf(
+                Message {
+                    role = Role.USER
+                    content = listOf(Text("""
+                        Generate a concise title (max 6 words) for a conversation starting with:
+
+                        "$userMessage"
+
+                        Reply with only the title, no quotes or extra punctuation.
+                    """.trimIndent()))
+                }
+            )
+        }
+        return (response.content.first() as Text).text.trim()
+    }
+
+}

--- a/golem-xiv-core/src/main/kotlin/cognition/DefaultCognitionRepository.kt
+++ b/golem-xiv-core/src/main/kotlin/cognition/DefaultCognitionRepository.kt
@@ -18,6 +18,7 @@
 
 package com.xemantic.ai.golem.core.cognition
 
+import com.xemantic.ai.golem.api.CognitionListItem
 import com.xemantic.ai.golem.api.EpistemicAgent
 import com.xemantic.ai.golem.api.PhenomenalExpression
 import com.xemantic.ai.golem.api.Phenomenon
@@ -306,5 +307,14 @@ class DefaultCognitionRepository(
             null
         }
     }
+
+    override suspend fun listCognitions(
+        limit: Int,
+        offset: Int
+    ): List<CognitionListItem> = memory.listCognitions(limit, offset)
+
+    override suspend fun isFirstExpression(
+        cognitionId: Long
+    ): Boolean = memory.getExpressionCount(cognitionId) == 1
 
 }

--- a/golem-xiv-presenter/src/commonMain/kotlin/MainPresenter.kt
+++ b/golem-xiv-presenter/src/commonMain/kotlin/MainPresenter.kt
@@ -114,6 +114,10 @@ class MainPresenter(
 
     private var currentNavigationTarget: Navigation.Target? = null
 
+    private val cognitionService = HttpClientCognitionService(apiClient)
+
+    private val golemOutputs = MutableSharedFlow<GolemOutput>()
+
     val headerPresenter = HeaderPresenter(
         scope,
         headerView,
@@ -125,13 +129,12 @@ class MainPresenter(
         sidebarView,
         toggles = toggleFlow,
         navigation,
-        themeChangesSink = themeChangesFlow
+        themeChangesSink = themeChangesFlow,
+        cognitionService = cognitionService,
+        golemOutputs = golemOutputs
     )
 
-    private val golemOutputs = MutableSharedFlow<GolemOutput>()
-
     private val pingService = HttpClientPingService(apiClient)
-    private val cognitionService = HttpClientCognitionService(apiClient)
 
     private lateinit var cognitionPresenter: CognitionPresenter
     private lateinit var cognitionView: CognitionView

--- a/golem-xiv-server/src/main/kotlin/GolemServer.kt
+++ b/golem-xiv-server/src/main/kotlin/GolemServer.kt
@@ -23,6 +23,7 @@ import com.xemantic.ai.golem.api.GolemError
 import com.xemantic.ai.golem.api.GolemOutput
 import com.xemantic.ai.golem.api.Phenomenon
 import com.xemantic.ai.golem.api.backend.GolemException
+import com.xemantic.ai.golem.cognizer.anthropic.AnthropicTitleGenerator
 import com.xemantic.ai.golem.cognizer.anthropic.AnthropicToolUseCognizer
 import com.xemantic.ai.golem.core.GolemXiv
 import com.xemantic.ai.golem.core.cognition.DefaultCognitionRepository
@@ -131,10 +132,13 @@ fun Application.module() {
         }
     )
 
+    val titleGenerator = AnthropicTitleGenerator(anthropic)
+
     val golem = GolemXiv(
         identity = identity,
         repository = repository,
         cognizer = anthropicCognizer,
+        titleGenerator = titleGenerator,
         golemScriptDependencyProvider = golemScriptDependencyProvider,
         outputs = outputs
     )
@@ -201,9 +205,9 @@ fun Route.golemApiRoute(
     }
 
     get("/cognitions") {
-//        call.respond(
-//            golem.contexts
-//        )
+        val limit = call.parameters["limit"]?.toIntOrNull() ?: 50
+        val offset = call.parameters["offset"]?.toIntOrNull() ?: 0
+        call.respond(golem.listCognitions(limit, offset))
     }
 
     put("/cognitions") {

--- a/golem-xiv-web/src/jsMain/resources/css/main.css
+++ b/golem-xiv-web/src/jsMain/resources/css/main.css
@@ -70,6 +70,28 @@ pre {
     margin-bottom: .9rem;
 }
 
+/* Past cognitions list - only visible when expanded */
+.app-navigation-rail:not(.max) .cognition-list-section {
+    display: none;
+}
+
+.cognition-list-section {
+    border-top: 1px solid var(--outline-variant);
+    margin-top: .5rem;
+    padding-top: .5rem;
+}
+
+.cognition-list {
+    max-height: 500px;
+}
+
+.cognition-list a {
+    padding: .5rem 1rem;
+    text-overflow: ellipsis;
+    overflow: hidden;
+    white-space: nowrap;
+}
+
 /* Navigation components */
 .app-navigation-bar {
     z-index: 200 !important;


### PR DESCRIPTION
## Summary

- Add a "Past Cognitions" list in the expanded navigation rail sidebar, allowing users to navigate to previous cognition sessions
- Implement auto-generation of cognition titles based on the first user message using LLM inference
- Display cognitions with their title (or fallback to "Cognition #ID" if no title exists)
- Add SSE event to notify clients when a cognition title is updated

## Changes

### API Layer (golem-xiv-api)
- Add CognitionListItem data class for listing cognitions
- Add GolemOutput.CognitionTitleUpdated SSE event type

### Backend (golem-xiv-api-backend, golem-xiv-neo4j, golem-xiv-core)
- Add listCognitions() and getExpressionCount() to CognitiveMemory interface
- Add listCognitions() and isFirstExpression() to CognitionRepository interface
- Implement Neo4j Cypher queries to list root cognitions (excluding child cognitions) ordered by initiation time
- Create TitleGenerator interface and AnthropicTitleGenerator implementation
- Integrate async title generation in GolemXiv.perceive() after first user message

### Server (golem-xiv-server)
- Implement GET /api/cognitions endpoint with pagination support
- Wire up title generator using the configured Anthropic instance

### Client (golem-xiv-api-client)
- Add listCognitions() method to CognitionService

### Frontend (golem-xiv-presenter, golem-xiv-web)
- Extend SidebarView and SidebarPresenter to handle cognition list display and selection
- Add cognition list UI component in HtmlNavigationRailView
- Auto-refresh list on new cognitions and title updates via SSE events
- Add CSS styles for the cognition list (visible only when navbar is expanded)

### Tests (golem-xiv-neo4j)
- Add tests for listCognitions (ordering, pagination, excluding child cognitions, title display)
- Add tests for getExpressionCount

## Test plan

- Run ./gradlew :golem-xiv-neo4j:test - verify new Neo4j tests pass
- Start the full stack and verify:
  - Expand navbar and see "Past Cognitions" section
  - Create a new cognition with a message
  - Verify title is auto-generated after first message
  - Verify cognition appears in the past cognitions list
  - Click on a past cognition to navigate to it