### PR TITLE
Batch Neo4j phenomenon content writes instead of incremental appends

### DIFF
--- a/golem-xiv-api-backend/src/main/kotlin/CognitionApi.kt
+++ b/golem-xiv-api-backend/src/main/kotlin/CognitionApi.kt
@@ -72,27 +72,6 @@ interface CognitionRepository {
         systemId: String
     ): Long
 
-    suspend fun appendText(
-        cognitionId: Long,
-        expressionId: Long,
-        phenomenonId: Long,
-        textDelta: String
-    )
-
-    suspend fun appendIntentPurpose(
-        cognitionId: Long,
-        expressionId: Long,
-        phenomenonId: Long,
-        purposeDelta: String
-    )
-
-    suspend fun appendIntentCode(
-        cognitionId: Long,
-        expressionId: Long,
-        phenomenonId: Long,
-        codeDelta: String
-    )
-
     suspend fun updateSystemPhenomena(
         cognitionId: Long,
         phenomena: List<String>
@@ -110,6 +89,28 @@ interface CognitionRepository {
     suspend fun maybeCulminatedWithIntent(
         cognitionId: Long
     ): Phenomenon.Intent?
+
+    suspend fun culminateTextPhenomenon(
+        cognitionId: Long,
+        expressionId: Long,
+        phenomenonId: Long,
+        text: String
+    )
+
+    suspend fun culminateIntentPhenomenon(
+        cognitionId: Long,
+        expressionId: Long,
+        phenomenonId: Long,
+        purpose: String,
+        code: String
+    )
+
+    suspend fun culminateFulfillmentPhenomenon(
+        cognitionId: Long,
+        expressionId: Long,
+        phenomenonId: Long,
+        result: String
+    )
 
 }
 
@@ -177,6 +178,11 @@ interface CognitiveMemory {
         phenomenonId: Long,
         type: StorageType
     ): String
+
+    suspend fun writePhenomenonContent(
+        phenomenonId: Long,
+        content: Map<StorageType, String>
+    )
 
 }
 

--- a/golem-xiv-core/src/main/kotlin/GolemXiv.kt
+++ b/golem-xiv-core/src/main/kotlin/GolemXiv.kt
@@ -181,11 +181,11 @@ class GolemXiv(
                         is ExecuteGolemScript.Result.Error -> result.message to true
                     }
 
-                    repository.appendText(
+                    repository.culminateFulfillmentPhenomenon(
                         cognitionId = cognitionId,
                         expressionId = expressionInfo.id,
                         phenomenonId = fulfillmentId,
-                        textDelta = text
+                        result = text
                     )
 
                     cognitionBroadcaster.emit(CognitionEvent.FulfillmentUnfolding(

--- a/golem-xiv-core/src/main/kotlin/cognition/DefaultCognitionRepository.kt
+++ b/golem-xiv-core/src/main/kotlin/cognition/DefaultCognitionRepository.kt
@@ -60,11 +60,11 @@ class DefaultCognitionRepository(
                         expressionId = info.id,
                         label = "Text"
                     )
-                    appendText(
+                    culminateTextPhenomenon(
                         cognitionId = cognitionId,
                         expressionId = info.id,
                         phenomenonId = id,
-                        textDelta = phenomenon.text
+                        text = phenomenon.text
                     )
                     Phenomenon.Text(
                         id = id,
@@ -137,45 +137,6 @@ class DefaultCognitionRepository(
             type = StorageType.SYSTEM_ID
         )
         return phenomenonId
-    }
-
-    override suspend fun appendText(
-        cognitionId: Long,
-        expressionId: Long,
-        phenomenonId: Long,
-        textDelta: String
-    ) {
-        memory.appendPhenomenonContent(
-            phenomenonId = phenomenonId,
-            content = textDelta,
-            type = StorageType.TEXT
-        )
-    }
-
-    override suspend fun appendIntentPurpose(
-        cognitionId: Long,
-        expressionId: Long,
-        phenomenonId: Long,
-        purposeDelta: String
-    ) {
-        memory.appendPhenomenonContent(
-            phenomenonId = phenomenonId,
-            content = purposeDelta,
-            type = StorageType.INTENT_PURPOSE
-        )
-    }
-
-    override suspend fun appendIntentCode(
-        cognitionId: Long,
-        expressionId: Long,
-        phenomenonId: Long,
-        codeDelta: String
-    ) {
-        memory.appendPhenomenonContent(
-            phenomenonId = phenomenonId,
-            content = codeDelta,
-            type = StorageType.INTENT_CODE
-        )
     }
 
     override suspend fun updateSystemPhenomena(
@@ -305,6 +266,46 @@ class DefaultCognitionRepository(
         } else {
             null
         }
+    }
+
+    override suspend fun culminateTextPhenomenon(
+        cognitionId: Long,
+        expressionId: Long,
+        phenomenonId: Long,
+        text: String
+    ) {
+        memory.writePhenomenonContent(
+            phenomenonId = phenomenonId,
+            content = mapOf(StorageType.TEXT to text)
+        )
+    }
+
+    override suspend fun culminateIntentPhenomenon(
+        cognitionId: Long,
+        expressionId: Long,
+        phenomenonId: Long,
+        purpose: String,
+        code: String
+    ) {
+        memory.writePhenomenonContent(
+            phenomenonId = phenomenonId,
+            content = mapOf(
+                StorageType.INTENT_PURPOSE to purpose,
+                StorageType.INTENT_CODE to code
+            )
+        )
+    }
+
+    override suspend fun culminateFulfillmentPhenomenon(
+        cognitionId: Long,
+        expressionId: Long,
+        phenomenonId: Long,
+        result: String
+    ) {
+        memory.writePhenomenonContent(
+            phenomenonId = phenomenonId,
+            content = mapOf(StorageType.TEXT to result)
+        )
     }
 
 }


### PR DESCRIPTION
## Summary

- Replace streaming append operations (`appendText`, `appendIntentPurpose`, `appendIntentCode`) with batch "culminate" operations that write all content at once when a content block completes
- `IntentCognizer` now accumulates purpose and code in memory buffers instead of persisting during streaming
- Add `writePhenomenonContent` method to `CognitiveMemory` for batch writes of multiple storage types in a single Neo4j transaction
- Reduces the number of Neo4j write transactions during streaming, improving performance

## Test plan

- [ ] Run existing Neo4j tests: `./gradlew :golem-xiv-neo4j:test`
- [ ] Run core tests: `./gradlew :golem-xiv-core:test`
- [ ] Verify full system works with manual testing (Neo4j + server + web client)

🤖 Generated with [Claude Code](https://claude.com/claude-code)