### PR TITLE
Add heartbeat to SSE endpoint

### DIFF
--- a/golem-xiv-server/src/main/kotlin/GolemServer.kt
+++ b/golem-xiv-server/src/main/kotlin/GolemServer.kt
@@ -164,6 +164,8 @@ fun Application.module() {
             val clientIp = call.request.origin.remoteAddress
             logger.info { "SSE client connected: $clientIp" }
 
+            heartbeat()
+
             sendGolemOutput(
                 GolemOutput.Welcome("You are connected to Golem XIV")
             )


### PR DESCRIPTION
Fixes #37

Added heartbeat mechanism to the Server-Sent Events (SSE) endpoint at `/events` to prevent load balancers from closing connections during periods of inactivity.

The implementation uses Ktor's built-in `heartbeat()` function which automatically sends periodic events to keep the connection alive.

---

Generated with [Claude Code](https://claude.ai/code)