### PR TITLE
Fix shadow jar missing version in filename

### DIFF
--- a/golem-xiv-server/build.gradle.kts
+++ b/golem-xiv-server/build.gradle.kts
@@ -96,6 +96,12 @@ tasks.named("shadowJar") {
     dependsOn("copyWebResources")
 }
 
+ktor {
+    fatJar {
+        archiveFileName.set("golem-xiv-server-${project.version}-all.jar")
+    }
+}
+
 listOf(
     "distTar",
     "distZip",


### PR DESCRIPTION
## Summary
- The Ktor plugin sets `archiveVersion` to empty by default on the `shadowJar` task, producing `golem-xiv-server-all.jar`
- The release workflow expects `golem-xiv-server-{version}-all.jar`, causing the artifact upload to fail and the release build to break
- Configure `ktor.fatJar.archiveFileName` to include the project version, matching the filename the workflow expects

Fixes https://github.com/xemantic/golem-xiv/actions/runs/21639711005

## Test plan
- [x] Verified locally that `./gradlew :golem-xiv-server:shadowJar -Pversion=0.1.0` produces `golem-xiv-server-0.1.0-all.jar`

🤖 Generated with [Claude Code](https://claude.com/claude-code)