### PR TITLE
Add golem-xiv-ddgs-client module

### DIFF
--- a/.github/workflows/build-ddgs-image.yml
+++ b/.github/workflows/build-ddgs-image.yml
@@ -1,0 +1,34 @@
+name: Build DDGS image
+
+on:
+  workflow_dispatch: # manual trigger
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository_owner }}/ddgs
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+
+    steps:
+      - name: Clone upstream repo
+        run: git clone --depth 1 https://github.com/deedy5/ddgs /tmp/ddgs
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: /tmp/ddgs
+          push: true
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.run_id }}

--- a/golem-xiv-ddgs-client/build.gradle.kts
+++ b/golem-xiv-ddgs-client/build.gradle.kts
@@ -35,5 +35,5 @@ dependencies {
     testImplementation(libs.kotlin.test)
     testImplementation(libs.kotlinx.coroutines.test)
     testImplementation(libs.xemantic.kotlin.test)
-    testImplementation("org.testcontainers:testcontainers:1.20.4")
+    testImplementation(libs.testcontainers)
 }

--- a/golem-xiv-ddgs-client/build.gradle.kts
+++ b/golem-xiv-ddgs-client/build.gradle.kts
@@ -16,29 +16,23 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-rootProject.name = "golem-xiv"
-
-pluginManagement {
-    includeBuild("build-logic")
+plugins {
+    alias(libs.plugins.kotlin.jvm)
+    alias(libs.plugins.kotlin.plugin.serialization)
+    id("golem.convention")
 }
 
-// TODO can it be a series of paths?
-include(
-    ":golem-xiv-json",
-    ":golem-xiv-api",
-    ":golem-xiv-api-backend",
-    ":golem-xiv-api-client",
-    ":golem-xiv-logging",
-    ":golem-xiv-core",
-    ":golem-xiv-neo4j",
-    ":golem-xiv-cognizer-anthropic",
-//    ":golem-xiv-cognizer-dashscope",
-    ":golem-xiv-playwright",
-    ":golem-xiv-ddgs-client",
-    ":golem-xiv-server",
-    ":golem-xiv-presenter",
-    ":golem-xiv-web",
-    ":golem-xiv-cli",
-    ":golem-xiv-neo4j-starter",
-    ":golem-xiv-kotlin-metadata",
-)
+dependencies {
+    api(libs.ktor.client.core)
+    api(libs.ktor.client.java)
+    api(libs.ktor.client.content.negotiation)
+    api(libs.ktor.serialization.kotlinx.json)
+    api(libs.kotlinx.serialization.json)
+
+    implementation(libs.kotlin.logging)
+
+    testImplementation(libs.kotlin.test)
+    testImplementation(libs.kotlinx.coroutines.test)
+    testImplementation(libs.xemantic.kotlin.test)
+    testImplementation("org.testcontainers:testcontainers:1.20.4")
+}

--- a/golem-xiv-ddgs-client/build.gradle.kts
+++ b/golem-xiv-ddgs-client/build.gradle.kts
@@ -29,7 +29,8 @@ dependencies {
     api(libs.ktor.serialization.kotlinx.json)
     api(libs.kotlinx.serialization.json)
 
-    implementation(libs.kotlin.logging)
+    implementation(project(":golem-xiv-logging"))
+    implementation(libs.logback.classic)
 
     testImplementation(libs.kotlin.test)
     testImplementation(libs.kotlinx.coroutines.test)

--- a/golem-xiv-ddgs-client/src/main/kotlin/com/xemantic/ai/golem/ddgs/DdgsClient.kt
+++ b/golem-xiv-ddgs-client/src/main/kotlin/com/xemantic/ai/golem/ddgs/DdgsClient.kt
@@ -1,0 +1,198 @@
+/*
+ * Golem XIV - Autonomous metacognitive AI system with semantic memory and self-directed research
+ * Copyright (C) 2025  Kazimierz Pogoda / Xemantic
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.xemantic.ai.golem.ddgs
+
+import io.github.oshai.kotlinlogging.KotlinLogging
+import io.ktor.client.*
+import io.ktor.client.call.*
+import io.ktor.client.request.*
+import io.ktor.http.*
+
+private val logger = KotlinLogging.logger {}
+
+/**
+ * Client for DDGS (DuckDuckGo Search) API server.
+ *
+ * @param baseUrl The base URL of the DDGS server (default: http://localhost:8000)
+ * @param httpClient The Ktor HTTP client to use for requests
+ */
+class DdgsClient(
+    private val baseUrl: String = "http://localhost:8000",
+    private val httpClient: HttpClient
+) {
+
+    /**
+     * Search for text results.
+     *
+     * @param query The search query
+     * @param region The region to search in (e.g., "wt-wt" for worldwide)
+     * @param safesearch Safe search level: "on", "moderate", or "off"
+     * @param timelimit Time limit for results (e.g., "d" for day, "w" for week, "m" for month)
+     * @param maxResults Maximum number of results to return
+     * @param backend Search backend to use (e.g., "duckduckgo", "bing", "google")
+     * @return List of text search results
+     */
+    suspend fun searchText(
+        query: String,
+        region: String? = null,
+        safesearch: String? = null,
+        timelimit: String? = null,
+        maxResults: Int? = null,
+        backend: String? = null
+    ): List<TextSearchResult> {
+        logger.debug { "Searching text: query='$query', region=$region, safesearch=$safesearch" }
+
+        return httpClient.post("$baseUrl/search/text") {
+            contentType(ContentType.Application.Json)
+            setBody(TextSearchRequest(
+                query = query,
+                region = region,
+                safesearch = safesearch,
+                timelimit = timelimit,
+                maxResults = maxResults,
+                backend = backend
+            ))
+        }.body()
+    }
+
+    /**
+     * Search for images.
+     *
+     * @param query The search query
+     * @param region The region to search in
+     * @param safesearch Safe search level
+     * @param timelimit Time limit for results
+     * @param maxResults Maximum number of results to return
+     * @return List of image search results
+     */
+    suspend fun searchImages(
+        query: String,
+        region: String? = null,
+        safesearch: String? = null,
+        timelimit: String? = null,
+        maxResults: Int? = null
+    ): List<ImageSearchResult> {
+        logger.debug { "Searching images: query='$query'" }
+
+        return httpClient.post("$baseUrl/search/images") {
+            contentType(ContentType.Application.Json)
+            setBody(ImageSearchRequest(
+                query = query,
+                region = region,
+                safesearch = safesearch,
+                timelimit = timelimit,
+                maxResults = maxResults
+            ))
+        }.body()
+    }
+
+    /**
+     * Search for news.
+     *
+     * @param query The search query
+     * @param region The region to search in
+     * @param safesearch Safe search level
+     * @param timelimit Time limit for results
+     * @param maxResults Maximum number of results to return
+     * @return List of news search results
+     */
+    suspend fun searchNews(
+        query: String,
+        region: String? = null,
+        safesearch: String? = null,
+        timelimit: String? = null,
+        maxResults: Int? = null
+    ): List<NewsSearchResult> {
+        logger.debug { "Searching news: query='$query'" }
+
+        return httpClient.post("$baseUrl/search/news") {
+            contentType(ContentType.Application.Json)
+            setBody(NewsSearchRequest(
+                query = query,
+                region = region,
+                safesearch = safesearch,
+                timelimit = timelimit,
+                maxResults = maxResults
+            ))
+        }.body()
+    }
+
+    /**
+     * Search for videos.
+     *
+     * @param query The search query
+     * @param region The region to search in
+     * @param safesearch Safe search level
+     * @param timelimit Time limit for results
+     * @param maxResults Maximum number of results to return
+     * @return List of video search results
+     */
+    suspend fun searchVideos(
+        query: String,
+        region: String? = null,
+        safesearch: String? = null,
+        timelimit: String? = null,
+        maxResults: Int? = null
+    ): List<VideoSearchResult> {
+        logger.debug { "Searching videos: query='$query'" }
+
+        return httpClient.post("$baseUrl/search/videos") {
+            contentType(ContentType.Application.Json)
+            setBody(VideoSearchRequest(
+                query = query,
+                region = region,
+                safesearch = safesearch,
+                timelimit = timelimit,
+                maxResults = maxResults
+            ))
+        }.body()
+    }
+
+    /**
+     * Search for books.
+     *
+     * @param query The search query
+     * @param maxResults Maximum number of results to return
+     * @return List of book search results
+     */
+    suspend fun searchBooks(
+        query: String,
+        maxResults: Int? = null
+    ): List<BookSearchResult> {
+        logger.debug { "Searching books: query='$query'" }
+
+        return httpClient.post("$baseUrl/search/books") {
+            contentType(ContentType.Application.Json)
+            setBody(BookSearchRequest(
+                query = query,
+                maxResults = maxResults
+            ))
+        }.body()
+    }
+
+    /**
+     * Check the health status of the DDGS server.
+     *
+     * @return Health status response
+     */
+    suspend fun checkHealth(): HealthStatus {
+        logger.debug { "Checking DDGS server health" }
+        return httpClient.get("$baseUrl/health").body()
+    }
+}

--- a/golem-xiv-ddgs-client/src/main/kotlin/com/xemantic/ai/golem/ddgs/DdgsClient.kt
+++ b/golem-xiv-ddgs-client/src/main/kotlin/com/xemantic/ai/golem/ddgs/DdgsClient.kt
@@ -68,7 +68,7 @@ class DdgsClient(
                 maxResults = maxResults,
                 backend = backend
             ))
-        }.body()
+        }.body<SearchResponse<TextSearchResult>>().results
     }
 
     /**
@@ -99,7 +99,7 @@ class DdgsClient(
                 timelimit = timelimit,
                 maxResults = maxResults
             ))
-        }.body()
+        }.body<SearchResponse<ImageSearchResult>>().results
     }
 
     /**
@@ -130,7 +130,7 @@ class DdgsClient(
                 timelimit = timelimit,
                 maxResults = maxResults
             ))
-        }.body()
+        }.body<SearchResponse<NewsSearchResult>>().results
     }
 
     /**
@@ -161,7 +161,7 @@ class DdgsClient(
                 timelimit = timelimit,
                 maxResults = maxResults
             ))
-        }.body()
+        }.body<SearchResponse<VideoSearchResult>>().results
     }
 
     /**
@@ -183,7 +183,7 @@ class DdgsClient(
                 query = query,
                 maxResults = maxResults
             ))
-        }.body()
+        }.body<SearchResponse<BookSearchResult>>().results
     }
 
     /**

--- a/golem-xiv-ddgs-client/src/main/kotlin/com/xemantic/ai/golem/ddgs/DdgsModel.kt
+++ b/golem-xiv-ddgs-client/src/main/kotlin/com/xemantic/ai/golem/ddgs/DdgsModel.kt
@@ -1,0 +1,128 @@
+/*
+ * Golem XIV - Autonomous metacognitive AI system with semantic memory and self-directed research
+ * Copyright (C) 2025  Kazimierz Pogoda / Xemantic
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.xemantic.ai.golem.ddgs
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+// Request DTOs
+
+@Serializable
+data class TextSearchRequest(
+    val query: String,
+    val region: String? = null,
+    val safesearch: String? = null,
+    val timelimit: String? = null,
+    @SerialName("max_results")
+    val maxResults: Int? = null,
+    val backend: String? = null
+)
+
+@Serializable
+data class ImageSearchRequest(
+    val query: String,
+    val region: String? = null,
+    val safesearch: String? = null,
+    val timelimit: String? = null,
+    @SerialName("max_results")
+    val maxResults: Int? = null
+)
+
+@Serializable
+data class NewsSearchRequest(
+    val query: String,
+    val region: String? = null,
+    val safesearch: String? = null,
+    val timelimit: String? = null,
+    @SerialName("max_results")
+    val maxResults: Int? = null
+)
+
+@Serializable
+data class VideoSearchRequest(
+    val query: String,
+    val region: String? = null,
+    val safesearch: String? = null,
+    val timelimit: String? = null,
+    @SerialName("max_results")
+    val maxResults: Int? = null
+)
+
+@Serializable
+data class BookSearchRequest(
+    val query: String,
+    @SerialName("max_results")
+    val maxResults: Int? = null
+)
+
+// Response DTOs
+
+@Serializable
+data class TextSearchResult(
+    val title: String,
+    val href: String,
+    val body: String
+)
+
+@Serializable
+data class ImageSearchResult(
+    val title: String,
+    val image: String,
+    val thumbnail: String,
+    val url: String,
+    val height: Int,
+    val width: Int,
+    val source: String
+)
+
+@Serializable
+data class NewsSearchResult(
+    val date: String,
+    val title: String,
+    val body: String,
+    val url: String,
+    val image: String? = null,
+    val source: String
+)
+
+@Serializable
+data class VideoSearchResult(
+    val title: String,
+    val description: String,
+    val duration: String,
+    @SerialName("embed_url")
+    val embedUrl: String,
+    val images: List<String>,
+    val uploader: String
+)
+
+@Serializable
+data class BookSearchResult(
+    val title: String,
+    val author: String,
+    val publisher: String,
+    val info: String,
+    val url: String,
+    val thumbnail: String
+)
+
+@Serializable
+data class HealthStatus(
+    val status: String
+)

--- a/golem-xiv-ddgs-client/src/main/kotlin/com/xemantic/ai/golem/ddgs/DdgsModel.kt
+++ b/golem-xiv-ddgs-client/src/main/kotlin/com/xemantic/ai/golem/ddgs/DdgsModel.kt
@@ -74,6 +74,11 @@ data class BookSearchRequest(
 // Response DTOs
 
 @Serializable
+data class SearchResponse<T>(
+    val results: List<T>
+)
+
+@Serializable
 data class TextSearchResult(
     val title: String,
     val href: String,
@@ -102,13 +107,21 @@ data class NewsSearchResult(
 )
 
 @Serializable
+data class VideoImages(
+    val large: String,
+    val medium: String,
+    val motion: String,
+    val small: String
+)
+
+@Serializable
 data class VideoSearchResult(
     val title: String,
     val description: String,
     val duration: String,
     @SerialName("embed_url")
     val embedUrl: String,
-    val images: List<String>,
+    val images: VideoImages,
     val uploader: String
 )
 

--- a/golem-xiv-ddgs-client/src/test/kotlin/com/xemantic/ai/golem/ddgs/DdgsClientTest.kt
+++ b/golem-xiv-ddgs-client/src/test/kotlin/com/xemantic/ai/golem/ddgs/DdgsClientTest.kt
@@ -1,0 +1,138 @@
+/*
+ * Golem XIV - Autonomous metacognitive AI system with semantic memory and self-directed research
+ * Copyright (C) 2025  Kazimierz Pogoda / Xemantic
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.xemantic.ai.golem.ddgs
+
+import com.xemantic.kotlin.test.have
+import com.xemantic.kotlin.test.should
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.Test
+
+class DdgsClientTest {
+
+    companion object {
+        @JvmStatic
+        @AfterAll
+        fun tearDown() {
+            TestDdgs.stop()
+        }
+    }
+
+    @Test
+    fun `should check health status`() = runTest {
+        // given
+        val client = TestDdgs.client
+
+        // when
+        val health = client.checkHealth()
+
+        // then
+        health should {
+            have(status == "ok")
+        }
+    }
+
+    @Test
+    fun `should search text`() = runTest {
+        // given
+        val client = TestDdgs.client
+
+        // when
+        val results = client.searchText(
+            query = "Kotlin programming language",
+            maxResults = 5
+        )
+
+        // then
+        assert(results.isNotEmpty())
+        assert(results.all { it.title.isNotBlank() })
+        assert(results.all { it.href.isNotBlank() })
+        assert(results.all { it.body.isNotBlank() })
+    }
+
+    @Test
+    fun `should search images`() = runTest {
+        // given
+        val client = TestDdgs.client
+
+        // when
+        val results = client.searchImages(
+            query = "kotlin logo",
+            maxResults = 3
+        )
+
+        // then
+        assert(results.isNotEmpty())
+        assert(results.all { it.title.isNotBlank() })
+        assert(results.all { it.image.isNotBlank() })
+        assert(results.all { it.url.isNotBlank() })
+    }
+
+    @Test
+    fun `should search news`() = runTest {
+        // given
+        val client = TestDdgs.client
+
+        // when
+        val results = client.searchNews(
+            query = "technology",
+            maxResults = 5
+        )
+
+        // then
+        assert(results.isNotEmpty())
+        assert(results.all { it.title.isNotBlank() })
+        assert(results.all { it.url.isNotBlank() })
+        assert(results.all { it.body.isNotBlank() })
+    }
+
+    @Test
+    fun `should search videos`() = runTest {
+        // given
+        val client = TestDdgs.client
+
+        // when
+        val results = client.searchVideos(
+            query = "kotlin tutorial",
+            maxResults = 3
+        )
+
+        // then
+        assert(results.isNotEmpty())
+        assert(results.all { it.title.isNotBlank() })
+        assert(results.all { it.embedUrl.isNotBlank() })
+    }
+
+    @Test
+    fun `should search books`() = runTest {
+        // given
+        val client = TestDdgs.client
+
+        // when
+        val results = client.searchBooks(
+            query = "programming",
+            maxResults = 5
+        )
+
+        // then
+        assert(results.isNotEmpty())
+        assert(results.all { it.title.isNotBlank() })
+        assert(results.all { it.url.isNotBlank() })
+    }
+}

--- a/golem-xiv-ddgs-client/src/test/kotlin/com/xemantic/ai/golem/ddgs/DdgsClientTest.kt
+++ b/golem-xiv-ddgs-client/src/test/kotlin/com/xemantic/ai/golem/ddgs/DdgsClientTest.kt
@@ -44,7 +44,7 @@ class DdgsClientTest {
 
         // then
         health should {
-            have(status == "ok")
+            have(status == "healthy")
         }
     }
 

--- a/golem-xiv-ddgs-client/src/test/kotlin/com/xemantic/ai/golem/ddgs/DdgsClientTest.kt
+++ b/golem-xiv-ddgs-client/src/test/kotlin/com/xemantic/ai/golem/ddgs/DdgsClientTest.kt
@@ -37,7 +37,7 @@ class DdgsClientTest {
     @Test
     fun `should check health status`() = runTest {
         // given
-        val client = TestDdgs.client
+        val client = DdgsClient(baseUrl = TestDdgs.baseUrl)
 
         // when
         val health = client.checkHealth()
@@ -46,12 +46,14 @@ class DdgsClientTest {
         health should {
             have(status == "healthy")
         }
+
+        client.close()
     }
 
     @Test
     fun `should search text`() = runTest {
         // given
-        val client = TestDdgs.client
+        val client = DdgsClient(baseUrl = TestDdgs.baseUrl)
 
         // when
         val results = client.searchText(
@@ -64,12 +66,14 @@ class DdgsClientTest {
         assert(results.all { it.title.isNotBlank() })
         assert(results.all { it.href.isNotBlank() })
         assert(results.all { it.body.isNotBlank() })
+
+        client.close()
     }
 
     @Test
     fun `should search images`() = runTest {
         // given
-        val client = TestDdgs.client
+        val client = DdgsClient(baseUrl = TestDdgs.baseUrl)
 
         // when
         val results = client.searchImages(
@@ -82,12 +86,14 @@ class DdgsClientTest {
         assert(results.all { it.title.isNotBlank() })
         assert(results.all { it.image.isNotBlank() })
         assert(results.all { it.url.isNotBlank() })
+
+        client.close()
     }
 
     @Test
     fun `should search news`() = runTest {
         // given
-        val client = TestDdgs.client
+        val client = DdgsClient(baseUrl = TestDdgs.baseUrl)
 
         // when
         val results = client.searchNews(
@@ -100,12 +106,14 @@ class DdgsClientTest {
         assert(results.all { it.title.isNotBlank() })
         assert(results.all { it.url.isNotBlank() })
         assert(results.all { it.body.isNotBlank() })
+
+        client.close()
     }
 
     @Test
     fun `should search videos`() = runTest {
         // given
-        val client = TestDdgs.client
+        val client = DdgsClient(baseUrl = TestDdgs.baseUrl)
 
         // when
         val results = client.searchVideos(
@@ -117,12 +125,14 @@ class DdgsClientTest {
         assert(results.isNotEmpty())
         assert(results.all { it.title.isNotBlank() })
         assert(results.all { it.embedUrl.isNotBlank() })
+
+        client.close()
     }
 
     @Test
     fun `should search books`() = runTest {
         // given
-        val client = TestDdgs.client
+        val client = DdgsClient(baseUrl = TestDdgs.baseUrl)
 
         // when
         val results = client.searchBooks(
@@ -134,5 +144,7 @@ class DdgsClientTest {
         assert(results.isNotEmpty())
         assert(results.all { it.title.isNotBlank() })
         assert(results.all { it.url.isNotBlank() })
+
+        client.close()
     }
 }

--- a/golem-xiv-ddgs-client/src/test/kotlin/com/xemantic/ai/golem/ddgs/TestDdgs.kt
+++ b/golem-xiv-ddgs-client/src/test/kotlin/com/xemantic/ai/golem/ddgs/TestDdgs.kt
@@ -35,7 +35,7 @@ object TestDdgs {
     private const val DDGS_PORT = 8000
 
     private val container: GenericContainer<*> by lazy {
-        GenericContainer(DockerImageName.parse("deedy5/ddgs:latest"))
+        GenericContainer(DockerImageName.parse("ghcr.io/xemantic/ddgs:latest"))
             .withExposedPorts(DDGS_PORT)
             .waitingFor(Wait.forHttp("/health").forStatusCode(200))
             .apply {

--- a/golem-xiv-ddgs-client/src/test/kotlin/com/xemantic/ai/golem/ddgs/TestDdgs.kt
+++ b/golem-xiv-ddgs-client/src/test/kotlin/com/xemantic/ai/golem/ddgs/TestDdgs.kt
@@ -1,0 +1,72 @@
+/*
+ * Golem XIV - Autonomous metacognitive AI system with semantic memory and self-directed research
+ * Copyright (C) 2025  Kazimierz Pogoda / Xemantic
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.xemantic.ai.golem.ddgs
+
+import io.ktor.client.*
+import io.ktor.client.engine.java.*
+import io.ktor.client.plugins.contentnegotiation.*
+import io.ktor.serialization.kotlinx.json.*
+import kotlinx.serialization.json.Json
+import org.testcontainers.containers.GenericContainer
+import org.testcontainers.containers.wait.strategy.Wait
+import org.testcontainers.utility.DockerImageName
+
+/**
+ * Test utility for managing DDGS Docker container in integration tests.
+ */
+object TestDdgs {
+
+    private const val DDGS_PORT = 8000
+
+    private val container: GenericContainer<*> by lazy {
+        GenericContainer(DockerImageName.parse("deedy5/ddgs:latest"))
+            .withExposedPorts(DDGS_PORT)
+            .waitingFor(Wait.forHttp("/health").forStatusCode(200))
+            .apply {
+                start()
+            }
+    }
+
+    val baseUrl: String by lazy {
+        "http://${container.host}:${container.getMappedPort(DDGS_PORT)}"
+    }
+
+    val httpClient: HttpClient by lazy {
+        HttpClient(Java) {
+            install(ContentNegotiation) {
+                json(Json {
+                    ignoreUnknownKeys = true
+                    prettyPrint = true
+                })
+            }
+        }
+    }
+
+    val client: DdgsClient by lazy {
+        DdgsClient(
+            baseUrl = baseUrl,
+            httpClient = httpClient
+        )
+    }
+
+    fun stop() {
+        container.stop()
+        httpClient.close()
+    }
+}

--- a/golem-xiv-ddgs-client/src/test/resources/logback.xml
+++ b/golem-xiv-ddgs-client/src/test/resources/logback.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+  ~ Golem XIV - Autonomous metacognitive AI system with semantic memory and self-directed research
+  ~ Copyright (C) 2025  Kazimierz Pogoda / Xemantic
+  ~
+  ~ This program is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU Affero General Public License as
+  ~ published by the Free Software Foundation, either version 3 of the
+  ~ License, or (at your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU Affero General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Affero General Public License
+  ~ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+  -->
+
+<!DOCTYPE configuration>
+
+<configuration>
+
+    <contextListener class="ch.qos.logback.classic.jul.LevelChangePropagator">
+        <!-- reset all previous level configurations of all j.u.l. loggers -->
+        <resetJUL>true</resetJUL>
+    </contextListener>
+
+    <import class="ch.qos.logback.classic.encoder.PatternLayoutEncoder"/>
+    <import class="ch.qos.logback.core.ConsoleAppender"/>
+
+    <appender name="STDOUT" class="ConsoleAppender">
+        <encoder class="PatternLayoutEncoder">
+            <pattern>%d{HH:mm:ss.SSS} %highlight(%-5level) %cyan([%thread]) %magenta(%logger{36}) - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="STDOUT"/>
+    </root>
+
+</configuration>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -23,6 +23,7 @@ neo4jBrowser = "2025.8.0"
 neo4jBrowserSha256 = "4ed8ca29a27519a79f7013258acbcb020649a7fef354e1e157c1dc8f0a83cef2"
 neo4jDriver = "6.0.2"
 neo4jMigrations = "3.1.0"
+testcontainers = "2.0.3"
 
 slf4j = "2.0.17"
 logback = "1.5.23"
@@ -70,6 +71,8 @@ neo4j = { module = "org.neo4j:neo4j", version.ref = "neo4j" }
 neo4j-harness = { module = "org.neo4j.test:neo4j-harness", version.ref = "neo4j" }
 neo4j-java-driver = { module = "org.neo4j.driver:neo4j-java-driver", version.ref = "neo4jDriver" }
 neo4j-migrations = { module = "eu.michael-simons.neo4j:neo4j-migrations", version.ref = "neo4jMigrations" }
+
+testcontainers = { module = "org.testcontainers:testcontainers", version.ref = "testcontainers" }
 
 ktor-sse = { module = "io.ktor:ktor-sse", version.ref = "ktor" }
 ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }


### PR DESCRIPTION
Implements Ktor-based client for DDGS (DuckDuckGo Search) API

Provides search methods for text, images, videos, news, and books.
Uses Testcontainers to spin up DDGS server for integration tests.
JVM-only module following project conventions.

Resolves #48

Generated with [Claude Code](https://claude.ai/code)