### PR TITLE
feat: serve index.html for unmatched URLs to support SPA routing

### DIFF
--- a/golem-xiv-server/src/main/kotlin/GolemServer.kt
+++ b/golem-xiv-server/src/main/kotlin/GolemServer.kt
@@ -176,6 +176,14 @@ fun Application.module() {
                 sendGolemOutput(it)
             }
         }
+
+        // SPA fallback: serve index.html for any unmatched GET request,
+        // enabling client-side routing (e.g. /cognitions/12 -> index.html)
+        get("{...}") {
+            call.resolveResource("index.html", "web")?.let {
+                call.respond(it)
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Adds a catch-all GET route as an SPA fallback in the Ktor server. Any GET request that doesn't match a static resource, API route, or SSE endpoint is now served index.html, enabling client-side routing (e.g. navigating directly to /cognitions/12 in a deployed environment).

Fixes #57

Generated with [Claude Code](https://claude.ai/code)