### PR TITLE
fix: compilation errors after anthropic-sdk-kotlin upgrade

### DIFF
--- a/golem-xiv-cognizer-anthropic/src/main/kotlin/AnthropicToolUseCognizer.kt
+++ b/golem-xiv-cognizer-anthropic/src/main/kotlin/AnthropicToolUseCognizer.kt
@@ -169,6 +169,8 @@ class AnthropicToolUseCognizer(
                             // no emission
                         }
 
+                        else -> {} // thinking is not enabled, ignore thinking blocks
+
                     }
                 }
 
@@ -198,6 +200,8 @@ class AnthropicToolUseCognizer(
                                 emit(result)
                             }
                         }
+
+                        else -> {} // thinking is not enabled, ignore thinking deltas
 
                     }
                 }

--- a/golem-xiv-server/src/main/kotlin/GolemServer.kt
+++ b/golem-xiv-server/src/main/kotlin/GolemServer.kt
@@ -95,7 +95,7 @@ fun Application.module() {
     )
 
     val anthropic = Anthropic {
-        defaultModel = Model.CLAUDE_OPUS_4_6
+        defaultModel = Model.CLAUDE_OPUS_4_6.id
         anthropicBeta = listOf(
             "fine-grained-tool-streaming-2025-05-14",
             "token-efficient-tools-2025-02-19",


### PR DESCRIPTION
## Summary
- Handle new thinking-related event variants (`Thinking`/`RedactedThinking` content blocks, `ThinkingDelta`/`SignatureDelta` deltas) in `AnthropicToolUseCognizer` with `else` branches — extended thinking is not enabled for this cognizer, so they are intentionally ignored
- Pass the model id string (`Model.CLAUDE_OPUS_4_6.id`) to `defaultModel` in `GolemServer`, which expects a `String` since the SDK upgrade

## Test plan
- `./gradlew build` (including tests) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)